### PR TITLE
save lines to sb buffer when feed ED(ESC[2J)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 .direnv
 .envrc
+compile_commands.json
+*.o
+*.so
+*.lo
+*.la
+.libs
+.cache
+build

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 #### WIP:
 
-+ push current screen to scrollback buffer when feed CUP(ESC[n;mH)
++ push current screen to scrollback buffer when feed ED(ESC[2J)

--- a/include/vterm.h
+++ b/include/vterm.h
@@ -437,6 +437,7 @@ typedef struct {
   int (*resize)(int rows, int cols, VTermStateFields *fields, void *user);
   int (*setlineinfo)(int row, const VTermLineInfo *newinfo, const VTermLineInfo *oldinfo, void *user);
   int (*sb_clear)(void *user);
+  void (*sb_pushline)(int row, void *user);
 } VTermStateCallbacks;
 
 typedef struct {

--- a/src/state.c
+++ b/src/state.c
@@ -1039,7 +1039,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     break;
 
   case 0x48: // CUP - ECMA-48 8.3.21
-    row = CSI_ARG_OR(args[0], 1);
+            row = CSI_ARG_OR(args[0], 1);
     col = argcount < 2 || CSI_ARG_IS_MISSING(args[1]) ? 1 : CSI_ARG(args[1]);
     // zero-based
     state->pos.row = row-1;
@@ -1092,9 +1092,13 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     case 2:
       rect.start_row = 0; rect.end_row = state->rows;
       rect.start_col = 0; rect.end_col = state->cols;
-      for(int row = rect.start_row; row < rect.end_row; row++)
+      for(int row = rect.start_row; row < rect.end_row; row++) {
+        // TODO: only push used line
+        if(state->callbacks && state->callbacks->sb_pushline)
+          (*state->callbacks->sb_pushline)(row, state->cbdata);
         set_lineinfo(state, row, FORCE, DWL_OFF, DHL_OFF);
-      erase(state, rect, selective);
+      }
+      erase(state, rect, selective);      break;
       break;
 
     case 3:


### PR DESCRIPTION
Libvterm doesn't save the current screen to scrollback buffer when feed CSI ED (CSI 2 J) now, but many terminals like alacritty have the opposite behavior. To keep consistency, let libvterm do the same thing.